### PR TITLE
handle ii kings

### DIFF
--- a/app/verse.hoon
+++ b/app/verse.hoon
@@ -61,9 +61,12 @@
     |^  ?+  site  [[404 ~] `(as-octs 'unexpected route')]
             [%verse %study ~]
           =-  [[302 ['location' -]~] ~]
+          =.  link-index        
+              ?~  (find "ii " index)  index
+              (weld "2" (oust [0 2] index))
           %^  cat  3
             'https://www.catholiccrossreference.online/fathers/index.php/'
-          (crip (cass index))
+          (crip (cass link-index))
         ::
             [%verse %verse ~]
           =;  svg


### PR DESCRIPTION
today the verse linked to https://www.catholiccrossreference.online/fathers/index.php/ii%20kings%207:9 which fails but https://www.catholiccrossreference.online/fathers/index.php/2%20kings%207:9 will succeed. so we need to swap `"ii"` for `"2" in the index which gets applied to the link

this has not been tested by me but looks like it will work