### PR TITLE
style: enhanced rumor readability

### DIFF
--- a/app/rumors/webui/index.hoon
+++ b/app/rumors/webui/index.hoon
@@ -88,7 +88,9 @@
 
     .rumor {
       margin-bottom: 2em;
-      text-shadow: 0 0 3px black;
+      background: rgba(0,0,0,0.05);
+      padding: 0.3rem 0.5rem;
+      width: fit-content;
     }
     '''
   ::


### PR DESCRIPTION
# Context

This swaps out the drop shadow for a transparent 5% black background. It has a similar effect of enhancing readability against the light background gradient as [the previous styling tweak](https://github.com/Fang-/suite/commit/1f8e2985456bfb5b13b2f4dd8c4f77cee5b9346d).

# Preview

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/16504501/218515392-8bac0288-686d-4fa9-adb5-44e959128022.png">
