### PR TITLE
rumors: subtle drop shadow

### DIFF
--- a/app/rumors/webui/index.hoon
+++ b/app/rumors/webui/index.hoon
@@ -88,6 +88,8 @@
 
     .rumor {
       margin-bottom: 2em;
+      text-shadow: 1px 1px 3px rgb(0 0 0 / 15%);
+      letter-spacing: 0.1px;
     }
     '''
   ::


### PR DESCRIPTION
# Changes

This adds a drop shadow to rumors text that is light (15% black), diffuse (3px radius), and only slightly offset (1px x 1px). The net effect is that it makes the text more legible on light backgrounds without distracting the eye.

Further, the text is spaced out an additional 0.1px, a subtle change that adds a bit of breathing room to the text.

# Preview

## Before

<img width="402" alt="Screenshot 2023-02-16 at 7 21 30 AM" src="https://user-images.githubusercontent.com/16504501/219409515-35c2f400-96a2-46dc-96c2-7d6692adea93.png">

<img width="967" alt="Screenshot 2023-02-16 at 7 14 44 AM" src="https://user-images.githubusercontent.com/16504501/219409507-ec2a6b55-e7fd-4ba8-81f8-4a05a7e9462c.png">

## After

<img width="396" alt="Screenshot 2023-02-16 at 7 21 23 AM" src="https://user-images.githubusercontent.com/16504501/219409511-c3c4cdbc-61d6-49f5-8c7b-ae8dccc22786.png">

<img width="932" alt="Screenshot 2023-02-16 at 7 14 38 AM" src="https://user-images.githubusercontent.com/16504501/219409502-c338ee4e-eb9a-485d-9125-a23f0633902f.png">
